### PR TITLE
[Fix] Added standard call for subject colour. To be removed later.

### DIFF
--- a/Sources/KognitaCore/Subject/SubjectRepository.swift
+++ b/Sources/KognitaCore/Subject/SubjectRepository.swift
@@ -40,7 +40,7 @@ extension Subject {
     public enum Create {
         public struct Data : Content {
             let name: String
-            let colorClass: Subject.ColorClass
+            let colorClass: Subject.ColorClass = .primary
             let description: String
             let category: String
         }


### PR DESCRIPTION
Added default colour for subject colour in database. The colour scheme is going to be removed later and this is a temporary removal of the subject colours to hide it from the end-users.